### PR TITLE
Fixed final state's instruction needing to be explicitly defined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "375812fa44dab6df41c195cd2f7fecb488f6c09fbaafb62807488cefab642bff"
 
 [[package]]
 name = "turing-machine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turing-machine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -65,4 +65,13 @@ impl TuringInstruction {
             to_state: String::from(code.next().unwrap().as_span().as_str()),
         }
     }
+    pub fn halt(index: (String, bool)) -> Self {
+        Self {
+            from_state: index.0.clone(),
+            from_value: index.1,
+            to_value: index.1,
+            movement: Movement::HALT,
+            to_state: index.0,
+        }
+    }
 }

--- a/src/turing.rs
+++ b/src/turing.rs
@@ -101,14 +101,37 @@ impl TuringMachine {
         }
     }
 
+    fn get_instruction(&self, index: (String, bool)) -> Option<TuringInstruction> {
+        match self.instructions.get(&index) {
+            Some(i) => Some(i.to_owned()),
+            None => {
+                if !self.final_states.contains(&self.current_state) {
+                    return None;
+                }
+
+                Some(TuringInstruction::halt(index))
+            }
+        }
+    }
+
+    pub fn get_current_instruction(&self) -> Option<TuringInstruction> {
+        let current_val: bool = self.tape[self.tape_position];
+        let index = (self.current_state.clone(), current_val);
+
+        self.get_instruction(index)
+    }
+
     pub fn step(&mut self) {
         let current_val: bool = self.tape[self.tape_position];
         let index = (self.current_state.clone(), current_val);
 
-        let Some(instruction) = self.instructions.get(&index) else {
-            panic!("No instruction given for state ({}, {})", self.current_state.clone(), current_val);
+        let Some(instruction) = self.get_instruction(index) else {
+            panic!(
+                "No instruction given for state ({}, {})",
+                self.current_state.clone(),
+                if current_val {"1"} else {"0"}
+            );
         };
-
         self.tape[self.tape_position] = instruction.to_value;
 
         match instruction.movement {
@@ -139,11 +162,6 @@ impl TuringMachine {
         }
 
         self.current_state = instruction.to_state.clone();
-    }
-
-    pub fn current_instruction(&self) -> Option<&TuringInstruction> {
-        self.instructions
-            .get(&(self.current_state.clone(), self.tape[self.tape_position]))
     }
 
     pub fn finished(&self) -> bool {

--- a/src/turing_widget.rs
+++ b/src/turing_widget.rs
@@ -118,7 +118,7 @@ impl Widget for TuringWidget {
                 Color32::BLACK,
             );
 
-            let ins = match self.tm.current_instruction() {
+            let ins = match self.tm.get_current_instruction() {
                 Some(txt) => format!("{}", txt),
                 None => String::from("ERROR: No instruction matches this situation!"),
             };


### PR DESCRIPTION
Now, the moment a TM finds itself in an undefined situation, it checks whether it's a final state and if it is then it halts without a problem. So now we don't need those two quintuples defining the final state behaviour.